### PR TITLE
Resize factor

### DIFF
--- a/oggm_3dviz/tools/utils.py
+++ b/oggm_3dviz/tools/utils.py
@@ -47,9 +47,6 @@ def resize_ds(
             {x: slice(x_middle_point - int(x_nr_of_grid_points / 2),
                       x_middle_point + int(x_nr_of_grid_points / 2))})
 
-
-
-
     if y_crop is not None:
         if 0. < y_crop < 1.:
             y_nr_of_grid_points = y_crop * len(ds[y])

--- a/oggm_3dviz/tools/utils.py
+++ b/oggm_3dviz/tools/utils.py
@@ -13,7 +13,7 @@ def resize_ds(
 ) -> xr.Dataset:
     """
     Resize a given dataset in a 'centered' manner, e.g. if the number of grid
-    points(set via 'x_crop' and 'y_crop' is given as 200, the dataset is resized to 200 grid points with 100
+    points(set via 'x_crop' and 'y_crop') is given as 200, the dataset is resized to 200 grid points with 100
     grid points on each side of the center. x_corp and y_crop can also be a crop factor.
     if x_crop is given as 0.5, the dataset is resized by half its width, always in a centered manner.
 

--- a/oggm_3dviz/tools/utils.py
+++ b/oggm_3dviz/tools/utils.py
@@ -4,27 +4,28 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 
 
-def resize_ds_by_nr_of_grid_points(
+def resize_ds(
         ds: xr.Dataset,
-        x_nr_of_grid_points: int | None = None,
-        y_nr_of_grid_points: int | None = None,
+        x_crop: int | float | None = None,
+        y_crop: int | float | None = None,
         x: str = "x",
         y: str = "y",
 ) -> xr.Dataset:
     """
     Resize a given dataset in a 'centered' manner, e.g. if the number of grid
     points is given as 200, the dataset is resized to 200 grid points with 100
-    grid points on each side of the center.
+    grid points on each side of the center. x_corp and y_crop can also be a crop factor.
+    if x_crop is given as 0.5, the dataset is resized by half its width, always in a centered manner.
 
     Parameters
     ----------
     ds: xr.Dataset
         Dataset to be resized.
-    x_nr_of_grid_points: int | None
-        Number of grid points in x direction. If None, the complete extend is
+    x_crop: float | int | None
+        Number of grid points in x direction or x-crop factor between 0 and 1. If None, the complete extend is
         used.
-    y_nr_of_grid_points: int | None
-        Number of grid points in y direction. If None, the complete extend is
+    y_crop: float | int | None
+        Number of grid points in y direction or y-crop factor between 0 and 1. If None, the complete extend is
         used.
     x: str
         Name of x coordinate of ds.
@@ -32,12 +33,28 @@ def resize_ds_by_nr_of_grid_points(
         Name of y coordinate of ds.
     """
     # resize map to given extend, if None the complete extend is used
-    if x_nr_of_grid_points is not None:
+
+
+    if x_crop is not None:
+        # doesn't make sense to use values bigger than 1.(100%) for cropping, as the data outside is not directly
+        # available
+        if 0. < x_crop <= 1.:
+            x_nr_of_grid_points = x_crop * len(ds[x])
+        else:
+            x_nr_of_grid_points = x_crop
         x_middle_point = int(len(ds[x]) / 2)
         ds = ds.isel(
             {x: slice(x_middle_point - int(x_nr_of_grid_points / 2),
                       x_middle_point + int(x_nr_of_grid_points / 2))})
-    if y_nr_of_grid_points is not None:
+
+
+
+
+    if y_crop is not None:
+        if 0. < y_crop < 1.:
+            y_nr_of_grid_points = y_crop * len(ds[y])
+        else:
+            y_nr_of_grid_points = y_crop
         y_middle_point = int(len(ds[y]) / 2)
         ds = ds.isel(
             {y: slice(y_middle_point - int(y_nr_of_grid_points / 2),

--- a/oggm_3dviz/tools/utils.py
+++ b/oggm_3dviz/tools/utils.py
@@ -13,7 +13,7 @@ def resize_ds(
 ) -> xr.Dataset:
     """
     Resize a given dataset in a 'centered' manner, e.g. if the number of grid
-    points is given as 200, the dataset is resized to 200 grid points with 100
+    points(set via 'x_crop' and 'y_crop' is given as 200, the dataset is resized to 200 grid points with 100
     grid points on each side of the center. x_corp and y_crop can also be a crop factor.
     if x_crop is given as 0.5, the dataset is resized by half its width, always in a centered manner.
 

--- a/oggm_3dviz/tools/viz.py
+++ b/oggm_3dviz/tools/viz.py
@@ -19,8 +19,8 @@ class Glacier3DViz:
         ice_thickness: str = 'simulated_thickness',
         time: str = "time",
         time_var_display: str = "calendar_year",
-        x_crop: int | None = None,
-        y_crop: int | None = None,
+        x_crop: int | float | None = None,
+        y_crop: int | float | None = None,
         additional_annotations: None | list = None,
         plotter_args: dict | None = None,
         add_mesh_topo_args: dict | None = None,
@@ -53,10 +53,10 @@ class Glacier3DViz:
             name of the time coordinate in the dataset to be displayed
         x_crop: float| int | None
             number of grid points in x direction or crop factor between 0 and 1, if None the complete extend
-            is used. See utils.resize_ds_by_nr_of_grid_points
+            is used. See utils.resize_ds
         y_crop: float | int | None
             number of grid points in y direction or crop factor between 0 and 1, if None the complete extend
-            is used. See utils.resize_ds_by_nr_of_grid_points
+            is used. See utils.resize_ds
         additional_annotations: None | list
             list of additional annotations to be added to the map, see
             oggm_3dviz.tools.map_annotations

--- a/oggm_3dviz/tools/viz.py
+++ b/oggm_3dviz/tools/viz.py
@@ -6,7 +6,7 @@ import pyvista as pv
 
 from .pyvista_xarray_ext import PyVistaGlacierSource
 from .texture import get_topo_texture
-from .utils import resize_ds_by_nr_of_grid_points, get_custom_colormap
+from .utils import resize_ds, get_custom_colormap
 
 
 class Glacier3DViz:
@@ -19,8 +19,8 @@ class Glacier3DViz:
         ice_thickness: str = 'simulated_thickness',
         time: str = "time",
         time_var_display: str = "calendar_year",
-        x_nr_of_grid_points: int | None = None,
-        y_nr_of_grid_points: int | None = None,
+        x_crop: int | None = None,
+        y_crop: int | None = None,
         additional_annotations: None | list = None,
         plotter_args: dict | None = None,
         add_mesh_topo_args: dict | None = None,
@@ -51,11 +51,11 @@ class Glacier3DViz:
             name of the time coordinate in the dataset
         time_var_display: str
             name of the time coordinate in the dataset to be displayed
-        x_nr_of_grid_points: int | None
-            number of grid points in x direction, if None the complete extend
+        x_crop: float| int | None
+            number of grid points in x direction or crop factor between 0 and 1, if None the complete extend
             is used. See utils.resize_ds_by_nr_of_grid_points
-        y_nr_of_grid_points: int | None
-            number of grid points in y direction, if None the complete extend
+        y_crop: float | int | None
+            number of grid points in y direction or crop factor between 0 and 1, if None the complete extend
             is used. See utils.resize_ds_by_nr_of_grid_points
         additional_annotations: None | list
             list of additional annotations to be added to the map, see
@@ -94,8 +94,8 @@ class Glacier3DViz:
         self.additional_annotations_use = additional_annotations
 
         # resize map to given extend, if None the complete extend is used
-        self.dataset = resize_ds_by_nr_of_grid_points(
-            dataset, x_nr_of_grid_points, y_nr_of_grid_points)
+        self.dataset = resize_ds(
+            dataset, x_crop, y_crop)
 
         # time_display for displaying total years only
         self.time = time


### PR DESCRIPTION
Introduced the option to also use a crop factor between 0 and 1 to crop the shown glacier(and surrounding) area without having to check what the current grid resolution and size is. 

As this functionality is extended the old functionality of resizing the plot, i renamed the former function to a more abstract name. `resize_ds_by_nr_of_grid_points => resize_ds`
Also the variables `x_nr_of_grid_points` and `y_nr_of_grid_points` got renamed to `x_crop` and `y_crop` as they are not necessarily representing number of grid points anymore.

Also added an example of this new option to the _general_styling_ tutorial notebook.